### PR TITLE
Adding API Microgateway deployment button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: sh configure-gateway.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## Deploy on Heroku
 
+The ‘Deploy to Heroku’ button enables users to deploy WSO2 API Microgateway on Heroku without leaving the web browser,
+ and with little configuration.
+
 Try WSO2 API Microgateway with direct deployment on Heroku:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/NipunaPrashan/heroku.git/tree/master)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # cloud-heroku-microgateway
+
+## Deploy on Heroku
+
+Try WSO2 API Microgateway with direct deployment on Heroku:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/NipunaPrashan/heroku.git/tree/master)
+
+## Documentation
+
+For more information about WSO2 API Microgateway, see these WSO2 documentations:
+
+- [Working with Hybrid API Management](https://docs.wso2.com/display/APICloud/Working+with+Hybrid+API+Management)
+- [WSO2 Cloud Blog](https://wso2.com/blogs/cloud/going-hybrid-on-premises-api-gateways/)

--- a/app.json
+++ b/app.json
@@ -9,10 +9,10 @@
       "description": "Your credentials will be required for accessing the services in API Cloud which are required for the functionality of the On Premise Gateway."
     },
     "WSO2_CLOUD_PASSWORD": {
-      "description": "Please enter WSO2 Cloud Account password"
+      "description": "Please enter WSO2 Cloud Account password."
     },
     "WSO2_CLOUD_ORG_KEY": {
-      "description": "Please enter your Organization Key used in WSO2 API Cloud"
+      "description": "Please enter your Organization Key used in WSO2 API Cloud."
     }
   },
   "formation": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,24 @@
+{
+  "name": "WSO2 API Microgateway",
+  "description": "Deploy your WSO2 API Microgateway on Heroku",
+  "repository": "https://github.com/NipunaPrashan/heroku.git",
+  "logo": "https://s3.amazonaws.com/wso2cloud-resources/images/api_cloud_logo.png",
+  "keywords": ["wso2", "api-gateway", "on-prem", "hybrid-cloud", "cloud", "api-management", "hybrid-api-management"],
+  "env": {
+    "WSO2_CLOUD_EMAIL": {
+      "description": "Your credentials will be required for accessing the services in API Cloud which are required for the functionality of the On Premise Gateway."
+    },
+    "WSO2_CLOUD_PASSWORD": {
+      "description": "Please enter WSO2 Cloud Account password"
+    },
+    "WSO2_CLOUD_ORG_KEY": {
+      "description": "Please enter your Organization Key used in WSO2 API Cloud"
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "standard-2x"
+    }
+  }
+}

--- a/configure-gateway.sh
+++ b/configure-gateway.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+UNZIPPED_FILE_NAME=wso2am-2.1.0
+DOWNLOAD_ZIP_FILE_NAME=wso2am-2.1.0.zip
+ON_PREM_GATEWAY_DOWNLOAD_LINK=https://s3.amazonaws.com/wso2cloud-resources/on-premise-gateway/wso2am-2.1.0.zip
+
+# Check for mandatory pre-requisites
+command -v wget >/dev/null 2>&1 || { echo >&2 "wget was not found. Please install wget first."; exit 1; }
+command -v unzip >/dev/null 2>&1 || { echo >&2 "unzip was not found. Please install unzip first."; exit 1; }
+
+if [ ! -f $DOWNLOAD_ZIP_FILE_NAME ]; then
+    echo "Setting up WSO2 API Microgateway..."
+    wget -q $ON_PREM_GATEWAY_DOWNLOAD_LINK
+fi
+
+if [ ! -f $DOWNLOAD_ZIP_FILE_NAME ]
+    then
+        echo "$DOWNLOAD_ZIP_FILE_NAME doesn't exist in current file location."
+        exit 1
+    else
+        if [ ! -d $UNZIPPED_FILE_NAME ]; then
+            #Unzip downloaded On-prem gateway to current location and remove the zip file.
+            unzip -q $DOWNLOAD_ZIP_FILE_NAME
+
+            #Binding Heroku dynamic port to Axis2 synapse port.
+            sed -i 's/JVM_MEM_OPTS="-Xms256m -Xmx1024m"/JVM_MEM_OPTS="-Xms256m -Xmx300m"/' $UNZIPPED_FILE_NAME/bin/wso2server.sh
+            sed -i 's#AUTOSTART="${WSO2_CLOUD_AUTOSTART:-"false"}"#AUTOSTART="${WSO2_CLOUD_AUTOSTART:-"true"}" \nsed -i "s/8280/$PORT/" wso2am-2.1.0/repository/conf/axis2/axis2.xml#' $UNZIPPED_FILE_NAME/bin/configure-gateway.sh
+        fi
+fi
+
+# Remove zip file after extracting files.
+if [ -f $DOWNLOAD_ZIP_FILE_NAME ]; then
+    rm -rf $DOWNLOAD_ZIP_FILE_NAME
+fi
+
+sh $UNZIPPED_FILE_NAME/bin/configure-gateway.sh

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+# Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.carbon.apimgt</groupId>
+    <artifactId>org.wso2.carbon.apimgt.micro.gateway</artifactId>
+    <version>2.1.0</version>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <executions>
+                    <execution>
+                        <id>WSO2 API Microgateway</id>
+                        <phase>generate-sources</phase>
+                        <goals/>
+                        <configuration/>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Purpose
> Deploy WSO2 API Microgateway to Heroku. The ‘Deploy to Heroku’ button enables users to deploy WSO2 API Microgateway to Heroku without leaving the web browser, and with little configuration. 

## Goals
> Simplify the API Microgateway deployment process to Heroku.

## Approach
> Users can click on the ‘Deploy to Heroku’ button to deploy API Microgateway to Heroku. Providing WSO2 account email, password and the organization key is enough to start the server on Heroku.

## User stories
> Click on the Deploy to Heroku button
![image](https://user-images.githubusercontent.com/8381009/37035020-2a27e4fc-2171-11e8-9674-1a50126e6981.png)

> Provide WSO2 account email, password and the organization key to configure the gateway
![image](https://user-images.githubusercontent.com/8381009/37034911-d8c6d2f8-2170-11e8-9c5e-f5b142e900e6.png)

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 8
 
## Learning
> N/A