### PR TITLE
Changing the name Microgateway to API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 ## Deploy on Heroku
 
-The ‘Deploy to Heroku’ button enables users to deploy WSO2 API Microgateway on Heroku without leaving the web browser,
+The ‘Deploy to Heroku’ button enables users to deploy WSO2 API Gateway on Heroku without leaving the web browser,
  and with little configuration.
 
-Try WSO2 API Microgateway with direct deployment on Heroku:
+Try WSO2 API Gateway with direct deployment on Heroku:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/NipunaPrashan/heroku.git/tree/master)
 
 ## Documentation
 
-For more information about WSO2 API Microgateway, see these WSO2 documentations:
+For more information about WSO2 API Gateway, see these WSO2 documentations:
 
 - [Working with Hybrid API Management](https://docs.wso2.com/display/APICloud/Working+with+Hybrid+API+Management)
 - [WSO2 Cloud Blog](https://wso2.com/blogs/cloud/going-hybrid-on-premises-api-gateways/)

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "WSO2 API Microgateway",
-  "description": "Deploy your WSO2 API Microgateway on Heroku",
+  "name": "WSO2 API Gateway",
+  "description": "Deploy your WSO2 API Gateway on Heroku",
   "repository": "https://github.com/wso2/cloud-heroku-microgateway.git",
   "logo": "https://s3.amazonaws.com/wso2cloud-resources/images/api_cloud_logo.png",
   "keywords": ["wso2", "api-gateway", "on-prem", "hybrid-cloud", "cloud", "api-management", "hybrid-api-management"],

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <executions>
                     <execution>
-                        <id>WSO2 API Microgateway</id>
+                        <id>WSO2 API Gateway</id>
                         <phase>generate-sources</phase>
                         <goals/>
                         <configuration/>


### PR DESCRIPTION
## Purpose
> Change the term Microgateway to API gateway.

## Goals
> WSO2 API gateway can be deployed on Heroku. API Gateway is the proper suitable name for the Heroku button.

## Approach
> Replace the text descriptions.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 8
 
## Learning
> N/A